### PR TITLE
Add `performs` to cut down on Active Job boilerplate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,42 @@
+## [0.3.0] - 2022-09-25
+
+- Add `performs` to help cut down Active Job boilerplate.
+
+  ```ruby
+  class Post::Publisher < ActiveRecord::AssociatedObject
+    performs :publish, queue_as: :important
+
+    def publish
+      …
+    end
+  end
+  ```
+
+  The above is the same as writing:
+
+  ```ruby
+  class Post::Publisher < ActiveRecord::AssociatedObject
+    class Job < ApplicationJob; end
+    class PublishJob < Job
+      queue_as :important
+
+      def perform(publisher, *arguments, **options)
+        publisher.publish(*arguments, **options)
+      end
+    end
+
+    def publish_later(*arguments, **options)
+      PublishJob.perform_later(self, *arguments, **options)
+    end
+
+    def publish
+      …
+    end
+  end
+  ```
+
+  See the README for more details.
+
 ## [0.2.0] - 2022-04-21
 
 - Require a `has_object` call on the record side to associate an object.

--- a/lib/active_record/associated_object.rb
+++ b/lib/active_record/associated_object.rb
@@ -1,9 +1,5 @@
 class ActiveRecord::AssociatedObject
-  autoload :Performs, "active_record/associated_object/performs"
-
   class << self
-    include Performs
-
     def inherited(klass)
       record_klass   = klass.module_parent
       record_name    = klass.module_parent_name.underscore

--- a/lib/active_record/associated_object.rb
+++ b/lib/active_record/associated_object.rb
@@ -1,5 +1,9 @@
 class ActiveRecord::AssociatedObject
+  autoload :Performs, "active_record/associated_object/performs"
+
   class << self
+    include Performs
+
     def inherited(klass)
       record_klass   = klass.module_parent
       record_name    = klass.module_parent_name.underscore

--- a/lib/active_record/associated_object/performs.rb
+++ b/lib/active_record/associated_object/performs.rb
@@ -33,7 +33,7 @@ module ActiveRecord::AssociatedObject::Performs
 
   private
     def find_or_define_job(detail: nil, superclass:)
-      name = "#{record_klass}::#{attribute_name.classify}::#{detail&.classify}Job"
+      name = "#{record_klass}::#{attribute_name.to_s.classify}::#{detail&.to_s&.classify}Job"
       name.safe_constantize || const_set(name, Class.new(superclass))
     end
 

--- a/lib/active_record/associated_object/performs.rb
+++ b/lib/active_record/associated_object/performs.rb
@@ -1,0 +1,46 @@
+module ActiveRecord::AssociatedObject::Performs
+  begin
+    ActiveRecord::AssociatedObject::Job # Attempt a load to see if the app has defined an override.
+  rescue NameError
+    # TODO: Replace ActiveJob::Base with ApplicationJob
+    class ActiveRecord::AssociatedObject::Job < ActiveJob::Base
+      def perform(object, method, *arguments, **options)
+        object.send(method, *arguments, **options)
+      end
+    end
+  end
+
+  def performs(*methods, **configs, &block)
+    if methods.empty?
+      apply_performs_to(job, **configs, &block)
+    else
+      jobs_by_method = methods.index_with { find_or_define_job(detail: _1, superclass: job) }
+      jobs_by_method.each_value { |job| apply_performs_to(job, **configs, &block) }
+
+      extend_source_from(jobs_by_method) do |method, job|
+        <<~RUBY
+          def #{method}_later(*arguments, **options)
+            #{job}.perform_later self, :#{method}, *arguments, **options
+          end
+        RUBY
+      end
+    end
+  end
+
+  def job
+    @job ||= find_or_define_job(superclass: ActiveRecord::AssociatedObject::Job)
+  end
+
+  private
+    def find_or_define_job(detail: nil, superclass:)
+      name = "#{record_klass}::#{attribute_name.classify}::#{detail&.classify}Job"
+      name.safe_constantize || const_set(name, Class.new(superclass))
+    end
+
+    def apply_performs_to(job_class, **configs, &block)
+      job_class.class_eval do
+        configs.each { public_send(_1, _2) }
+        yield if block_given?
+      end
+    end
+end

--- a/lib/active_record/associated_object/performs.rb
+++ b/lib/active_record/associated_object/performs.rb
@@ -1,12 +1,4 @@
 module ActiveRecord::AssociatedObject::Performs
-  begin
-    ActiveRecord::AssociatedObject::Job # Attempt a load to see if the app has defined an override.
-  rescue NameError
-    # TODO: Replace ActiveJob::Base with ApplicationJob
-    class ActiveRecord::AssociatedObject::Job < ActiveJob::Base
-    end
-  end
-
   def performs(method = nil, **configs, &block)
     job = method ? find_or_define_method_job(method) : job
     apply_performs_to(job, **configs, &block)
@@ -19,7 +11,7 @@ module ActiveRecord::AssociatedObject::Performs
   end
 
   def job
-    @job ||= "Job".safe_constantize || const_set("Job", Class.new(ActiveRecord::AssociatedObject::Job))
+    @job ||= "Job".safe_constantize || const_set("Job", Class.new(ApplicationJob))
   end
 
   private

--- a/lib/active_record/associated_object/performs.rb
+++ b/lib/active_record/associated_object/performs.rb
@@ -5,7 +5,7 @@ module ActiveRecord::AssociatedObject::Performs
 
     class_eval <<~RUBY, __FILE__, __LINE__ + 1 if method
       def #{method}_later(*arguments, **options)
-        #{job}.perform_later self, *arguments, **options
+        #{job}.perform_later(self, *arguments, **options)
       end
     RUBY
   end

--- a/lib/active_record/associated_object/performs.rb
+++ b/lib/active_record/associated_object/performs.rb
@@ -33,7 +33,7 @@ module ActiveRecord::AssociatedObject::Performs
 
   private
     def find_or_define_job(detail: nil, superclass:)
-      name = "#{record_klass}::#{attribute_name.to_s.classify}::#{detail&.to_s&.classify}Job"
+      name = "#{detail&.to_s&.classify}Job"
       name.safe_constantize || const_set(name, Class.new(superclass))
     end
 

--- a/lib/active_record/associated_object/performs.rb
+++ b/lib/active_record/associated_object/performs.rb
@@ -1,13 +1,17 @@
 module ActiveRecord::AssociatedObject::Performs
   def performs(method = nil, **configs, &block)
-    job = method ? safe_define_method_job(method) : job
-    apply_performs_to(job, **configs, &block)
+    if method.nil?
+      apply_performs_to(job, **configs, &block)
+    else
+      job = safe_define_method_job(method)
+      apply_performs_to(job, **configs, &block)
 
-    class_eval <<~RUBY, __FILE__, __LINE__ + 1 if method
-      def #{method}_later(*arguments, **options)
-        #{job}.perform_later(self, *arguments, **options)
-      end
-    RUBY
+      class_eval <<~RUBY, __FILE__, __LINE__ + 1
+        def #{method}_later(*arguments, **options)
+          #{job}.perform_later(self, *arguments, **options)
+        end
+      RUBY
+    end
   end
 
   def job

--- a/lib/active_record/associated_object/performs.rb
+++ b/lib/active_record/associated_object/performs.rb
@@ -1,9 +1,11 @@
 module ActiveRecord::AssociatedObject::Performs
   def performs(method = nil, **configs, &block)
+    @job ||= safe_define("Job") { ApplicationJob }
+
     if method.nil?
-      apply_performs_to(job, **configs, &block)
+      apply_performs_to(@job, **configs, &block)
     else
-      job = safe_define("#{method}_job".classify) { self.job }
+      job = safe_define("#{method}_job".classify) { @job }
       apply_performs_to(job, **configs, &block)
 
       job.class_eval <<~RUBY, __FILE__, __LINE__ + 1 unless job.instance_method(:perform).owner == job
@@ -18,10 +20,6 @@ module ActiveRecord::AssociatedObject::Performs
         end
       RUBY
     end
-  end
-
-  def job
-    @job ||= safe_define("Job") { ApplicationJob }
   end
 
   private

--- a/lib/active_record/associated_object/performs.rb
+++ b/lib/active_record/associated_object/performs.rb
@@ -1,6 +1,6 @@
 module ActiveRecord::AssociatedObject::Performs
   def performs(method = nil, **configs, &block)
-    job = method ? find_or_define_method_job(method) : job
+    job = method ? safe_define_method_job(method) : job
     apply_performs_to(job, **configs, &block)
 
     class_eval <<~RUBY, __FILE__, __LINE__ + 1 if method
@@ -15,7 +15,7 @@ module ActiveRecord::AssociatedObject::Performs
   end
 
   private
-    def find_or_define_method_job(method)
+    def safe_define_method_job(method)
       safe_define("#{method}_job".classify) { job }.tap do |job|
         job.class_eval <<~RUBY, __FILE__, __LINE__ + 1 unless job.instance_method(:perform).owner == job
           def perform(object, *arguments, **options)

--- a/lib/active_record/associated_object/railtie.rb
+++ b/lib/active_record/associated_object/railtie.rb
@@ -2,6 +2,11 @@ class ActiveRecord::AssociatedObject::Railtie < Rails::Railtie
   initializer "integrations.include" do
     ActiveRecord::AssociatedObject.include Kredis::Attributes       if defined?(Kredis)
     ActiveRecord::AssociatedObject.include GlobalID::Identification if defined?(GlobalID)
+
+    ActiveSupport.on_load :active_job do
+      require "active_record/associated_object/performs"
+      ActiveRecord::AssociatedObject.extend ActiveRecord::AssociatedObject::Performs
+    end
   end
 
   initializer "object_association.setup" do

--- a/test/active_record/associated_object_test.rb
+++ b/test/active_record/associated_object_test.rb
@@ -26,6 +26,14 @@ class ActiveRecord::AssociatedObjectTest < ActiveSupport::TestCase
     assert_equal [ @publisher ], Post::Publisher.where(id: 1)
   end
 
+  def test_introspection
+    assert_equal Post, @publisher.record_klass
+    assert_equal Post, Post::Publisher.record_klass
+
+    assert_equal :publisher, @publisher.attribute_name
+    assert_equal :publisher, Post::Publisher.attribute_name
+  end
+
   def test_unscoped_passthrough
     # TODO: lol what's this actually supposed to do? Need to look more into GlobalID.
     # https://github.com/rails/globalid/blob/3ddb0f87fd5c22b3330ab2b4e5c41a85953ac886/lib/global_id/locator.rb#L164

--- a/test/active_record/associated_object_test.rb
+++ b/test/active_record/associated_object_test.rb
@@ -75,7 +75,7 @@ class ActiveRecord::AssociatedObjectTest < ActiveSupport::TestCase
   def test_active_job_integration
     @publisher.performed = false
 
-    assert_performed_with job: Post::Publisher::PublishJob, args: [ @publisher ] do
+    assert_performed_with job: Post::Publisher::PublishJob, args: [ @publisher ], queue: "important" do
       @publisher.publish_later
     end
 

--- a/test/boot/associated_object.rb
+++ b/test/boot/associated_object.rb
@@ -14,6 +14,7 @@ class Post::Publisher < ApplicationRecord::AssociatedObject
 
   kredis_datetime :publish_at
 
+  performs queue_as: :not_really_important
   performs :publish, queue_as: :important, discard_on: ActiveJob::DeserializationError
 
   def after_update_commit

--- a/test/boot/associated_object.rb
+++ b/test/boot/associated_object.rb
@@ -14,7 +14,7 @@ class Post::Publisher < ApplicationRecord::AssociatedObject
 
   kredis_datetime :publish_at
 
-  performs :publish
+  performs :publish, queue_as: :important, discard_on: ActiveJob::DeserializationError
 
   def after_update_commit
     self.captured_title = post.title

--- a/test/boot/associated_object.rb
+++ b/test/boot/associated_object.rb
@@ -14,6 +14,8 @@ class Post::Publisher < ApplicationRecord::AssociatedObject
 
   kredis_datetime :publish_at
 
+  performs :publish
+
   def after_update_commit
     self.captured_title = post.title
   end
@@ -22,13 +24,7 @@ class Post::Publisher < ApplicationRecord::AssociatedObject
     throw :abort
   end
 
-  def publish_later
-    PublishJob.perform_later self
-  end
-
-  class PublishJob < ActiveJob::Base
-    def perform(publisher)
-      publisher.performed = true
-    end
+  def publish
+    self.performed = true
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,9 @@ Kredis.configurator = Class.new { def config_for(name) { db: "1" } end }.new
 
 GlobalID.app = "test"
 
+class ApplicationJob < ActiveJob::Base
+end
+
 require_relative "boot/active_record"
 require_relative "boot/associated_object"
 


### PR DESCRIPTION
```ruby
class Post::Publisher < ActiveRecord::AssociatedObject
  performs :publish, queue_as: :important

  def publish
    …
  end
end
```

The above is the same as writing:

```ruby
class Post::Publisher < ActiveRecord::AssociatedObject
  class Job < ApplicationJob; end
  class PublishJob < Job
    queue_as :important

    def perform(publisher, *arguments, **options)
      publisher.publish(*arguments, **options)
    end
  end

  def publish_later(*arguments, **options)
    PublishJob.perform_later(self, *arguments, **options)
  end

  def publish
    …
  end
end
```

See the README for more details.