### PR TITLE
Require the version file by default

### DIFF
--- a/lib/active_record/associated_object.rb
+++ b/lib/active_record/associated_object.rb
@@ -39,4 +39,5 @@ class ActiveRecord::AssociatedObject
   end
 end
 
+require_relative "associated_object/version"
 require_relative "associated_object/railtie" if defined?(Rails::Railtie)


### PR DESCRIPTION
I tried to use `ActiveRecord::AssociatedObject::VERSION`, but the constant didn't exist. I needed to require
'active_record/associated_object/version' to use that constant.