### PR TITLE
Define methods on child class, not ActiveRecord::AssociatedObject

### DIFF
--- a/lib/active_record/associated_object.rb
+++ b/lib/active_record/associated_object.rb
@@ -9,10 +9,10 @@ class ActiveRecord::AssociatedObject
         raise ArgumentError, "#{record_klass} isn't valid; can only associate with ActiveRecord::Base subclasses"
       end
 
-      alias_method record_name, :record
-      define_singleton_method(:record_klass)   { record_klass }
-      define_singleton_method(:attribute_name) { attribute_name }
-      delegate :record_klass, :attribute_name, to: :class
+      klass.alias_method record_name, :record
+      klass.define_singleton_method(:record_klass)   { record_klass }
+      klass.define_singleton_method(:attribute_name) { attribute_name }
+      klass.delegate :record_klass, :attribute_name, to: :class
     end
 
     def respond_to_missing?(...) = record_klass.respond_to?(...) || super

--- a/test/active_record/associated_object_test.rb
+++ b/test/active_record/associated_object_test.rb
@@ -9,6 +9,9 @@ class ActiveRecord::AssociatedObjectTest < ActiveSupport::TestCase
     super
     @post = Post.first
     @publisher = @post.publisher
+
+    @author = Author.first
+    @archiver = @author.archiver
   end
 
   def test_associated_object_alias
@@ -32,6 +35,12 @@ class ActiveRecord::AssociatedObjectTest < ActiveSupport::TestCase
 
     assert_equal :publisher, @publisher.attribute_name
     assert_equal :publisher, Post::Publisher.attribute_name
+
+    assert_equal Author, @archiver.record_klass
+    assert_equal Author, Author::Archiver.record_klass
+
+    assert_equal :archiver, @archiver.attribute_name
+    assert_equal :archiver, Author::Archiver.attribute_name
   end
 
   def test_unscoped_passthrough

--- a/test/boot/active_record.rb
+++ b/test/boot/active_record.rb
@@ -18,6 +18,8 @@ end
 
 class Author < ApplicationRecord
   has_many :posts
+
+  has_object :archiver
 end
 
 class Post < ApplicationRecord

--- a/test/boot/associated_object.rb
+++ b/test/boot/associated_object.rb
@@ -29,3 +29,6 @@ class Post::Publisher < ApplicationRecord::AssociatedObject
     self.performed = true
   end
 end
+
+class Author::Archiver < ApplicationRecord::AssociatedObject
+end


### PR DESCRIPTION
This was defining methods directly on ActiveRecord::AssociatedObject instead of Author/Post, which means that the last `has_object` call is the only record_klass / attribute_name that's set.

This resulted in cryptic errors in ActiveJob deserialization. Ex:

```
Author
  has_object :archiver
  # id 456

Post
  has_object :publisher
  # id 123

Author.find(456).archiver.archive_later
```

Enqueues a job with gid://app/Author::Archiver/456

Then raises:

```
ActiveJob::DeserializationError:
  Error while trying to deserialize arguments: Couldn't find Post with 'id'=456
```

The reason is that if Post is loaded after Author, then Author::Archiver.record_klass returned Post.