### PR TITLE
Make active_job-performs an optional dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in active_record-associated_object.gemspec
 gemspec
 
 gem "rake", "~> 13.0"
@@ -14,6 +13,7 @@ gem "sqlite3"
 # Integrations to setup and test with.
 gem "kredis"
 gem "activejob"
+gem "active_job-performs"
 gem "railties"
 
 gem "minitest-sprint", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     active_record-associated_object (0.4.1)
-      active_job-performs
       activerecord (>= 6.1)
 
 GEM
@@ -133,6 +132,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_job-performs
   active_record-associated_object!
   activejob
   debug

--- a/active_record-associated_object.gemspec
+++ b/active_record-associated_object.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "activerecord", ">= 6.1"
-  spec.add_dependency "active_job-performs"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/active_record/associated_object/railtie.rb
+++ b/lib/active_record/associated_object/railtie.rb
@@ -1,11 +1,15 @@
 class ActiveRecord::AssociatedObject::Railtie < Rails::Railtie
   initializer "integrations.include" do
-    ActiveRecord::AssociatedObject.include Kredis::Attributes       if defined?(Kredis)
-    ActiveRecord::AssociatedObject.include GlobalID::Identification if defined?(GlobalID)
+    config.after_initialize do
+      ActiveRecord::AssociatedObject.include Kredis::Attributes       if defined?(Kredis)
+      ActiveRecord::AssociatedObject.include GlobalID::Identification if defined?(GlobalID)
 
-    ActiveSupport.on_load :active_job do
-      require "active_job/performs"
-      ActiveRecord::AssociatedObject.extend ActiveJob::Performs
+      ActiveSupport.on_load :active_job do
+        require "active_job/performs"
+        ActiveRecord::AssociatedObject.extend ActiveJob::Performs
+      rescue LoadError
+        # We haven't bundled active_job-performs, so we're continuing without it.
+      end
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,6 +16,7 @@ require "minitest/autorun"
 
 # Simulate Rails app boot and run the railtie initializers manually.
 ActiveRecord::AssociatedObject::Railtie.run_initializers
+ActiveSupport.run_load_hooks :after_initialize, Rails::Railtie
 
 Kredis.configurator = Class.new { def config_for(name) { db: "1" } end }.new
 


### PR DESCRIPTION
To update and get the same behavior, you must explicitly put `active_job-performs` in your Gemfile:

```ruby
gem "active_job-performs"
gem "active_record-associated_object"
```

Also, I'm wrapping the integrations in a `config.after_initialize` so gem order in the Gemfile shouldn't matter. E.g. if you put kredis after associated_object we should still be able to connect.