### PR TITLE
Drop outdated comments from active_record-associated_object.gemspec

### DIFF
--- a/active_record-associated_object.gemspec
+++ b/active_record-associated_object.gemspec
@@ -26,9 +26,5 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
   spec.add_dependency "activerecord", ">= 6.1"
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
 end


### PR DESCRIPTION
This PR cleans up some initially-generated comments.