### PR TITLE
Test support for Active Record's composite primary keys

### DIFF
--- a/test/boot/active_record.rb
+++ b/test/boot/active_record.rb
@@ -9,6 +9,12 @@ ActiveRecord::Schema.define do
     t.string :title
     t.integer :author_id
   end
+
+  create_table :post_comments, primary_key: [:post_id, :author_id] do |t|
+    t.integer :post_id, null: false
+    t.integer :author_id, null: false
+    t.string :body
+  end
 end
 
 # Shim what an app integration would look like.
@@ -17,14 +23,23 @@ class ApplicationRecord < ActiveRecord::Base
 end
 
 class Author < ApplicationRecord
-  has_many :posts
+  has_many :posts,    dependent: :destroy
+  has_many :comments, dependent: :destroy, class_name: "Post::Comment"
 
   has_object :archiver
 end
 
 class Post < ApplicationRecord
   belongs_to :author
+  has_many :comments, dependent: :destroy
 
   has_object :mailroom,  after_touch: true
   has_object :publisher, after_update_commit: true, before_destroy: :prevent_errant_post_destroy
+end
+
+class Post::Comment < ApplicationRecord
+  belongs_to :post
+  belongs_to :author
+
+  has_object :rating
 end

--- a/test/boot/associated_object.rb
+++ b/test/boot/associated_object.rb
@@ -8,6 +8,9 @@ end
 
 class ApplicationRecord::AssociatedObject < ActiveRecord::AssociatedObject; end
 
+class Author::Archiver < ApplicationRecord::AssociatedObject
+end
+
 class Post::Publisher < ApplicationRecord::AssociatedObject
   mattr_accessor :performed,      default: false
   mattr_accessor :captured_title, default: nil
@@ -30,5 +33,11 @@ class Post::Publisher < ApplicationRecord::AssociatedObject
   end
 end
 
-class Author::Archiver < ApplicationRecord::AssociatedObject
+class Post::Comment::Rating < ActiveRecord::AssociatedObject
+  kredis_flag :moderated
+
+  def great?
+    # TODO: Fix namespaced records generating a :"post/comments" alias instead of `post_comment` or `comment`
+    record.body == "First!!!!"
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -29,7 +29,8 @@ require_relative "boot/active_record"
 require_relative "boot/associated_object"
 
 author = Author.create!
-author.posts.create! id: 1, title: "First post"
+post = author.posts.create! id: 1, title: "First post"
+author.comments.create! post: post, body: "First!!!!"
 
 class ActiveSupport::TestCase
   teardown { Kredis.clear_all }


### PR DESCRIPTION
Looks like we already support this, this just adds tests so we know if it breaks.