### PR TITLE
Minimally require Ruby 3.0

### DIFF
--- a/active_record-associated_object.gemspec
+++ b/active_record-associated_object.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary  = "Associate a Ruby PORO with an Active Record class and have it quack like one."
   spec.homepage = "https://github.com/kaspth/active_record-associated_object"
   spec.license  = "MIT"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"]    = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Looks like I just bumped to 2.7 in d9b2b01 back when I wrote the gem.

I had accidentally used a Ruby 3.0 syntax feature here https://github.com/kaspth/active_record-associated_object/blob/9b182b3eca357f0c6620dc655005bea1a62e2db0/lib/active_record/associated_object.rb#L18

And forgot to test on 2.7 in CI, meaning that I never caught that the gem can't load on 2.7. So we've effectively been 3.0 exclusive forever, so any users on this are already minimally on 3.0 and I'd rather bump to 3.0 since 2.7 is EOL'ed.