### PR TITLE
Improve object shape friendliness

### DIFF
--- a/lib/active_record/associated_object/object_association.rb
+++ b/lib/active_record/associated_object/object_association.rb
@@ -1,7 +1,5 @@
 module ActiveRecord::AssociatedObject::ObjectAssociation
-  def self.included(klass)
-    klass.extend ClassMethods
-  end
+  def self.included(klass) = klass.extend(ClassMethods)
 
   using Module.new {
     refine Module do

--- a/lib/active_record/associated_object/object_association.rb
+++ b/lib/active_record/associated_object/object_association.rb
@@ -1,5 +1,7 @@
 module ActiveRecord::AssociatedObject::ObjectAssociation
-  def self.included(klass) = klass.extend ClassMethods
+  def self.included(klass)
+    klass.extend ClassMethods
+  end
 
   using Module.new {
     refine Module do

--- a/lib/active_record/associated_object/object_association.rb
+++ b/lib/active_record/associated_object/object_association.rb
@@ -1,4 +1,6 @@
 module ActiveRecord::AssociatedObject::ObjectAssociation
+  extend ActiveSupport::Concern
+
   using Module.new {
     refine Module do
       def extend_source_from(chunks, &block)
@@ -9,15 +11,34 @@ module ActiveRecord::AssociatedObject::ObjectAssociation
     end
   }
 
-  def has_object(*names, **callbacks)
-    extend_source_from(names) do |name|
-      "def #{name}; @#{name} ||= #{self.name}::#{name.to_s.classify}.new(self); end"
-    end
+  included do
+    class_attribute :associated_object_ivar_names,
+      default: [],
+      instance_accessor: false,
+      instance_predicate: false
+  end
 
-    extend_source_from(names) do |name|
-      callbacks.map do |callback, method|
-        "#{callback} { #{name}.#{method == true ? callback : method} }"
+  class_methods do
+    def has_object(*names, **callbacks)
+      self.associated_object_ivar_names += names.map { |n| :"@#{n}" }
+
+      extend_source_from(names) do |name|
+        "def #{name}; @#{name} ||= #{self.name}::#{name.to_s.classify}.new(self); end"
+      end
+
+      extend_source_from(names) do |name|
+        callbacks.map do |callback, method|
+          "#{callback} { #{name}.#{method == true ? callback : method} }"
+        end
       end
     end
+  end
+
+  def init_internals
+    self.class.associated_object_ivar_names.each do |name|
+      instance_variable_set(name, nil)
+    end
+
+    super
   end
 end

--- a/lib/active_record/associated_object/railtie.rb
+++ b/lib/active_record/associated_object/railtie.rb
@@ -16,7 +16,7 @@ class ActiveRecord::AssociatedObject::Railtie < Rails::Railtie
 
     ActiveSupport.on_load :active_record do
       require "active_record/associated_object/object_association"
-      extend ActiveRecord::AssociatedObject::ObjectAssociation
+      include ActiveRecord::AssociatedObject::ObjectAssociation
     end
   end
 end

--- a/test/active_record/associated_object_test.rb
+++ b/test/active_record/associated_object_test.rb
@@ -87,6 +87,24 @@ class ActiveRecord::AssociatedObjectTest < ActiveSupport::TestCase
     refute_empty Post.all
   end
 
+  def test_ivar_initialization
+    # Confirm that it initializes the instance variables to nil
+    assert_includes Author.new.instance_variables, :@archiver
+    assert_nil Author.new.instance_variable_get(:@archiver)
+    assert_includes Post.new.instance_variables, :@publisher
+    assert_nil Post.new.instance_variable_get(:@publisher)
+
+    # It keeps the classes separate
+    refute_includes Post.new.instance_variables, :@archiver
+
+    # It still includes the default Rails variables
+    assert_equal Post.new.instance_variable_get(:@new_record), true
+
+    assert_equal Author.associated_object_ivar_names, %i[@archiver @classified @fortification]
+    assert_equal Post.associated_object_ivar_names, %i[@mailroom @publisher]
+    assert_equal Post::Comment.associated_object_ivar_names, %i[@rating]
+  end
+
   def test_kredis_integration
     Time.new(2022, 4, 20, 1).tap do |publish_at|
       @publisher.publish_at.value = publish_at

--- a/test/active_record/associated_object_test.rb
+++ b/test/active_record/associated_object_test.rb
@@ -88,21 +88,12 @@ class ActiveRecord::AssociatedObjectTest < ActiveSupport::TestCase
   end
 
   def test_ivar_initialization
-    # Confirm that it initializes the instance variables to nil
-    assert_includes Author.new.instance_variables, :@archiver
-    assert_nil Author.new.instance_variable_get(:@archiver)
-    assert_includes Post.new.instance_variables, :@publisher
-    assert_nil Post.new.instance_variable_get(:@publisher)
-
-    # It keeps the classes separate
-    refute_includes Post.new.instance_variables, :@archiver
+    # Confirm that it initializes the instance variable to nil
+    assert_includes Author.new.instance_variables, :@associated_objects
+    assert_nil Author.new.instance_variable_get(:@associated_objects)
 
     # It still includes the default Rails variables
     assert_equal Post.new.instance_variable_get(:@new_record), true
-
-    assert_equal Author.associated_object_ivar_names, %i[@archiver @classified @fortification]
-    assert_equal Post.associated_object_ivar_names, %i[@mailroom @publisher]
-    assert_equal Post::Comment.associated_object_ivar_names, %i[@rating]
   end
 
   def test_kredis_integration


### PR DESCRIPTION
I'm mimicking what Jean did here:
https://github.com/rails/rails/pull/47023
https://github.com/rails/rails/pull/47032
https://github.com/rails/rails/pull/47049

Otherwise, if you've got multiple associated objects on a single class, you can end up with a lot of permutations of object shapes because the instance variables are lazily defined in whatever order the associated objects may or may not have been called in.

Author has these 3 instance variables:

1. `@archiver`
2. `@classified`
3. `@fortification`


That leaves you with these permutations of object shapes:

1. (none called)
4. `@archiver`
5. `@archiver @classified`
6. `@archiver @fortification`
7. `@archiver @classified @fortification`
8. `@archiver @fortification @classified`
9. `@classified`
10. `@classified @archiver`
11. `@classified @fortification`
12. `@classified @archiver @fortification`
13. `@classified @fortification @archiver`
14. `@fortification`
15. `@fortification @archiver`
16. `@fortification @classified`
17. `@fortification @archiver @classified`
18. `@fortification @classified @archiver`


Now, we'll have 1 shape:
1. `@archiver @classified @fortification`