### PR TITLE
Fix: Extensions aren't loaded in development/test

### DIFF
--- a/lib/active_record/associated_object/object_association.rb
+++ b/lib/active_record/associated_object/object_association.rb
@@ -14,7 +14,7 @@ module ActiveRecord::AssociatedObject::ObjectAssociation
   module ClassMethods
     def has_object(*names, **callbacks)
       extend_source_from(names) do |name|
-        "def #{name}; (@associated_objects ||= {})[:#{name}] ||= #{name.to_s.classify}.new(self); end"
+        "def #{name}; (@associated_objects ||= {})[:#{name}] ||= #{const_get(name.to_s.classify)}.new(self); end"
       end
 
       extend_source_from(names) do |name|


### PR DESCRIPTION
PR #19 previously loaded the associated object class when the has_object was defined, so that extensions would get run. It seems like that code got lost in a rebase. So now, extensions only run on boot if eager loading is enabled (which it is in production). Otherwise they aren't loaded until the first time the associated object gets used.

RE: https://github.com/kaspth/active_record-associated_object/pull/19#issuecomment-1901172299