### PR TITLE
`has_object`: support plural Associated Object names

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ We've fixed this so you don't need to care, but this is what's happening.
 > [!TIP]
 > You can pass multiple names too: `has_object :publisher, :classified, :fortification`. I recommend `-[i]er`, `-[i]ed` and `-ion` as the general naming conventions for your Associated Objects.
 
+> [!TIP]
+> Plural Associated Object names are also supported: `Account.has_object :seats` will look up `Account::Seats`.
+
 See how we're always expecting a link to the model, here `post`?
 
 Because of that, you can rely on `post` from the associated object:

--- a/lib/active_record/associated_object/object_association.rb
+++ b/lib/active_record/associated_object/object_association.rb
@@ -14,7 +14,7 @@ module ActiveRecord::AssociatedObject::ObjectAssociation
   module ClassMethods
     def has_object(*names, **callbacks)
       extend_source_from(names) do |name|
-        "def #{name}; (@associated_objects ||= {})[:#{name}] ||= #{const_get(name.to_s.classify)}.new(self); end"
+        "def #{name}; (@associated_objects ||= {})[:#{name}] ||= #{const_get(name.to_s.camelize)}.new(self); end"
       end
 
       extend_source_from(names) do |name|

--- a/test/active_record/associated_object/object_association_test.rb
+++ b/test/active_record/associated_object/object_association_test.rb
@@ -7,9 +7,9 @@ class ActiveRecord::AssociatedObject::ObjectAssociationTest < ActiveSupport::Tes
     assert_kind_of Post::Mailroom, Post.first.mailroom
 
     author = Author.first
-    assert_kind_of Author::Archiver,      author.archiver
-    assert_kind_of Author::Classified,    author.classified
-    assert_kind_of Author::Fortification, author.fortification
+    assert_kind_of Author::Archiver,       author.archiver
+    assert_kind_of Author::Classified,     author.classified
+    assert_kind_of Author::Fortifications, author.fortifications
   end
 
   test "callback passing for standard PORO" do

--- a/test/boot/associated_object.rb
+++ b/test/boot/associated_object.rb
@@ -2,10 +2,10 @@ class ApplicationRecord::AssociatedObject < ActiveRecord::AssociatedObject; end
 
 class Author::Archiver < ApplicationRecord::AssociatedObject; end
 # TODO: Replace with Data.define once on Ruby 3.2.
-Author::Classified    = Struct.new(:author)
-Author::Fortification = Struct.new(:author)
+Author::Classified     = Struct.new(:author)
+Author::Fortifications = Struct.new(:author)
 
-Author.has_object :archiver, :classified, :fortification
+Author.has_object :archiver, :classified, :fortifications
 
 class Post::Mailroom < Struct.new(:record)
   mattr_accessor :touched, default: false


### PR DESCRIPTION
So `Account.has_object :seats` can look up `Account::Seats`, instead of erroneously looking for `Account::Seat`.

Plural Associated Object names were always meant to be supported, it was just an oversight on my part that `classify` singularizes.

cc @garrettdimon @natematykiewicz @julianrubisch