### PR TITLE
Support Polymorphic Associated Objects

### DIFF
--- a/lib/active_record/associated_object.rb
+++ b/lib/active_record/associated_object.rb
@@ -1,10 +1,7 @@
 class ActiveRecord::AssociatedObject
   class Polymorphic < self
     def self.inherited(klass)
-      if name = klass.module_parent_name
-        super
-        class_eval "def #{name.demodulize.underscore}? = record.is_a?(#{klass.record_klass})"
-      end
+      super if klass.module_parent_name
     end
   end
 

--- a/lib/active_record/associated_object.rb
+++ b/lib/active_record/associated_object.rb
@@ -1,4 +1,13 @@
 class ActiveRecord::AssociatedObject
+  class Polymorphic < self
+    def self.inherited(klass)
+      if name = klass.module_parent_name
+        super
+        class_eval "def #{name.demodulize.underscore}? = record.is_a?(#{klass.record_klass})"
+      end
+    end
+  end
+
   class << self
     def inherited(klass)
       record_klass   = klass.module_parent

--- a/test/boot/associated_object.rb
+++ b/test/boot/associated_object.rb
@@ -55,3 +55,33 @@ class Post::Comment::Rating < ActiveRecord::AssociatedObject
 end
 
 Post::Comment.has_object :rating
+
+# Can locate subclasses by grepping for `< Pricing`
+class Pricing < ActiveRecord::AssociatedObject::Polymorphic
+  # Here, `record` will return the post for Post::Pricing objects and the comment for Post::Comment::Pricings.
+
+  def something_conditional
+    execute_behavior if post?
+  end
+end
+
+class Post::Pricing < Pricing
+  def something_conditional
+    # Or just only implement the behavior in one class and thus rely on Polymorphism?
+  end
+end
+
+class Post::Comment::Pricing < Pricing
+  def something_conditional
+    # Nothing to do for comment
+  end
+end
+
+p Pricing.new(Post.new).post? # => true
+p Post::Pricing.new(Post.new).post? # => true
+
+p Pricing.new(Post::Comment.new).post? # => false
+p Post::Comment::Pricing.new(Post::Comment.new).post? # => false
+
+p Pricing.new(Post::Comment.new).comment? # => true
+p Post::Comment::Pricing.new(Post::Comment.new).comment? # => true

--- a/test/boot/associated_object.rb
+++ b/test/boot/associated_object.rb
@@ -59,29 +59,10 @@ Post::Comment.has_object :rating
 # Can locate subclasses by grepping for `< Pricing`
 class Pricing < ActiveRecord::AssociatedObject::Polymorphic
   # Here, `record` will return the post for Post::Pricing objects and the comment for Post::Comment::Pricings.
-
-  def something_conditional
-    execute_behavior if post?
-  end
 end
 
 class Post::Pricing < Pricing
-  def something_conditional
-    # Or just only implement the behavior in one class and thus rely on Polymorphism?
-  end
 end
 
 class Post::Comment::Pricing < Pricing
-  def something_conditional
-    # Nothing to do for comment
-  end
 end
-
-p Pricing.new(Post.new).post? # => true
-p Post::Pricing.new(Post.new).post? # => true
-
-p Pricing.new(Post::Comment.new).post? # => false
-p Post::Comment::Pricing.new(Post::Comment.new).post? # => false
-
-p Pricing.new(Post::Comment.new).comment? # => true
-p Post::Comment::Pricing.new(Post::Comment.new).comment? # => true


### PR DESCRIPTION
Sometimes there's certain behavior you'd like to share between multiple objects. However, Associated Object's design was purposefully written to only support associating with one distinct class.

This tries to shimmy that open a bit more, so you can do:

```ruby
class Pricing < ActiveRecord::AssociatedObject::Polymorphic
end

class Post::Pricing < Pricing
end

class Comment::Pricing < Pricing
end
```

cc @garrettdimon @julianrubisch @natematykiewicz 