### PR TITLE
Facilitate an `ApplicationRecord::AssociatedObject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,17 @@ You can see real life examples in these blog posts:
 
 If your team is using Associated Objects, we're more than happy to feature any write ups here.
 
+### Setting up an `ApplicationRecord::AssociatedObject`
+
+In case you need to define default logic exclusive to your Associated Objects you can set up a common base class in `app/models/application_record/associated_object.rb`.
+
+```ruby
+class ApplicationRecord::AssociatedObject < ActiveRecord::AssociatedObject
+end
+```
+
+We'll set this up when you run the generator below too.
+
 ### Use the generator to help write Associated Objects
 
 To set up the `Post::Publisher` from above, you can call `bin/rails generate associated Post::Publisher`.

--- a/lib/active_record/associated_object.rb
+++ b/lib/active_record/associated_object.rb
@@ -1,19 +1,19 @@
 class ActiveRecord::AssociatedObject
   class << self
-    def inherited(klass)
-      record_klass   = klass.module_parent
-      record_name    = klass.module_parent_name.demodulize.underscore
-      attribute_name = klass.to_s.demodulize.underscore.to_sym
+    def associate_with_record
+      record_klass   = module_parent
+      record_name    = module_parent_name.demodulize.underscore
+      attribute_name = to_s.demodulize.underscore.to_sym
 
-      unless record_klass.respond_to?(:descends_from_active_record?) && record_klass.descends_from_active_record?
-        raise ArgumentError, "#{record_klass} isn't valid; can only associate with ActiveRecord::Base subclasses"
-      end
+      raise ArgumentError, "#{record_klass} isn't valid; can only associate with ActiveRecord::Base subclasses" \
+        unless record_klass.respond_to?(:descends_from_active_record?) && record_klass.descends_from_active_record?
 
-      klass.alias_method record_name, :record
-      klass.define_singleton_method(:record_klass)   { record_klass }
-      klass.define_singleton_method(:attribute_name) { attribute_name }
-      klass.delegate :record_klass, :attribute_name, to: :class
+      alias_method record_name, :record
+      define_singleton_method(:record_klass)   { record_klass }
+      define_singleton_method(:attribute_name) { attribute_name }
+      delegate :record_klass, :attribute_name, to: :class
     end
+    def inherited(klass) = klass.associate_with_record
 
     def extension(&block)
       record_klass.class_eval(&block)

--- a/test/boot/associated_object.rb
+++ b/test/boot/associated_object.rb
@@ -1,5 +1,8 @@
 class ApplicationRecord::AssociatedObject < ActiveRecord::AssociatedObject; end
 
+p ApplicationRecord::AssociatedObject.record_klass
+p ApplicationRecord::AssociatedObject.attribute_name
+
 class Author::Archiver < ApplicationRecord::AssociatedObject; end
 # TODO: Replace with Data.define once on Ruby 3.2.
 Author::Classified     = Struct.new(:author)


### PR DESCRIPTION
Lets you define an abstract to share any common behavior you may need among Associated Objects:

```ruby
# app/models/application_record/associated_object.rb
class ApplicationRecord::AssociatedObject < ActiveRecord::AssociatedObject
end
```

I don't know what that common behavior may be yet, but I figure it's a good idea to expose.