### PR TITLE
Fix ActiveJob::Performs not being automatically extended

### DIFF
--- a/lib/active_record/associated_object/railtie.rb
+++ b/lib/active_record/associated_object/railtie.rb
@@ -6,14 +6,14 @@ class ActiveRecord::AssociatedObject::Railtie < Rails::Railtie
     end
   end
 
-  initializer "object_association.setup" do
-    ActiveSupport.on_load :active_job do
-      require "active_job/performs"
-      ActiveRecord::AssociatedObject.extend ActiveJob::Performs
-    rescue LoadError
-      # We haven't bundled active_job-performs, so we're continuing without it.
-    end
+  initializer "active_job.performs" do
+    require "active_job/performs"
+    ActiveRecord::AssociatedObject.extend ActiveJob::Performs if defined?(ActiveJob::Performs)
+  rescue LoadError
+    # We haven't bundled active_job-performs, so we're continuing without it.
+  end
 
+  initializer "object_association.setup" do
     ActiveSupport.on_load :active_record do
       require "active_record/associated_object/object_association"
       include ActiveRecord::AssociatedObject::ObjectAssociation

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,13 +4,15 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "rails/railtie"
 require "kredis"
-require "active_job"
-require "global_id"
 require "debug"
 require "logger"
 
 require "active_record"
 require "active_record/associated_object"
+
+require "global_id"
+require "active_job"
+require "active_job/performs"
 
 require "minitest/autorun"
 


### PR DESCRIPTION
`ActiveSupport.on_load :active_job` may not fire after the application has loaded (since it happens when Active Job is first mentioned and then it's loaded), which means any Associated Objects loaded would not have `performs` defined and we'd raise.

The short curcuit was to only inject performs if users were using Active Job, but it's too clever.

We're now being less clever and letting bundler load every gem first via deferring our extension to the others in `config.after_initialize`.