### PR TITLE
Expose `record` on the Associated Object class level.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,17 @@ end
 ### Extending the Active Record from within the Associated Object
 
 Since `has_object` eager-loads the Associated Object class, you can also move
-any integrating code into a provided `extension` block:
+any integrating code into the Associated Object.
+
+If you've got a few extensions, you can use `record` to access the Active Record class:
+
+```ruby
+class Post::Publisher < ActiveRecord::AssociatedObject
+  record.has_many :contracts, dependent: :destroy # `record` returns `Post` here.
+end
+```
+
+Alternatively, if you have many extensions, use the `extension` block:
 
 > [!NOTE]
 > Technically, `extension` is just `Post.class_eval` but with syntactic sugar.

--- a/lib/active_record/associated_object.rb
+++ b/lib/active_record/associated_object.rb
@@ -10,6 +10,7 @@ class ActiveRecord::AssociatedObject
       end
 
       klass.alias_method record_name, :record
+      klass.define_singleton_method(:record)         { record_klass }
       klass.define_singleton_method(:record_klass)   { record_klass }
       klass.define_singleton_method(:attribute_name) { attribute_name }
       klass.delegate :record_klass, :attribute_name, to: :class

--- a/test/boot/associated_object.rb
+++ b/test/boot/associated_object.rb
@@ -41,9 +41,8 @@ Post.has_object :mailroom,  after_touch: true
 Post.has_object :publisher, after_update_commit: true, before_destroy: :prevent_errant_post_destroy
 
 class Post::Comment::Rating < ActiveRecord::AssociatedObject
+  record.scope :great, -> { where(body: "First!!!!") }
   extension do
-    scope :great, -> { where(body: "First!!!!") }
-
     def rated_great? = rating.great?
   end
 


### PR DESCRIPTION
If you've got few extensions using the wrapping `extension do` block feels a bit much. Similarly using `record_klass` feels off.

Instead we alias `record_klass` as just `record` on the Associated Object class level to return the Active Record class.

Now, for example, part of the Action Mailbox internals could be rewritten as:

```ruby
class ActionMailbox::InboundEmail::Incineration < ActiveRecord::AssociatedObject
  record.after_update_commit :incinerate_later, if: -> { ActionMailbox.incinerate && status_previously_changed? && processed? }
  record.delegate :incinerate_later, to: :incineration

  # …
end
```

which feels like it has a slightly nicer flow than `extension do` here.