### PR TITLE
BREAKING: Replace `record_klass` with `record` & remove `record_klass`

### DIFF
--- a/lib/active_record/associated_object.rb
+++ b/lib/active_record/associated_object.rb
@@ -1,35 +1,35 @@
 class ActiveRecord::AssociatedObject
-  class << self
-    def inherited(klass)
-      record_klass   = klass.module_parent
-      record_name    = klass.module_parent_name.demodulize.underscore
-      attribute_name = klass.to_s.demodulize.underscore.to_sym
+  extend ActiveModel::Naming
 
-      unless record_klass.respond_to?(:descends_from_active_record?) && record_klass.descends_from_active_record?
-        raise ArgumentError, "#{record_klass} isn't valid; can only associate with ActiveRecord::Base subclasses"
+  class << self
+    def inherited(new_object)
+      new_object.associated_via(new_object.module_parent)
+    end
+
+    def associated_via(record)
+      unless record.respond_to?(:descends_from_active_record?) && record.descends_from_active_record?
+        raise ArgumentError, "#{record} isn't a valid namespace; can only associate with ActiveRecord::Base subclasses"
       end
 
-      klass.alias_method record_name, :record
-      klass.define_singleton_method(:record)         { record_klass }
-      klass.define_singleton_method(:record_klass)   { record_klass }
-      klass.define_singleton_method(:attribute_name) { attribute_name }
-      klass.delegate :record_klass, :attribute_name, to: :class
+      @record, @attribute_name = record, model_name.element.to_sym
+      alias_method record.model_name.element, :record
     end
+
+    attr_reader :record, :attribute_name
+    delegate :primary_key, :unscoped, :transaction, to: :record
 
     def extension(&block)
-      record_klass.class_eval(&block)
+      record.class_eval(&block)
     end
 
-    def respond_to_missing?(...) = record_klass.respond_to?(...) || super
-    delegate :unscoped, :transaction, :primary_key, to: :record_klass
-
     def method_missing(method, ...)
-      if !record_klass.respond_to?(method) then super else
-        record_klass.public_send(method, ...).then do |value|
+      if !record.respond_to?(method) then super else
+        record.public_send(method, ...).then do |value|
           value.respond_to?(:each) ? value.map(&attribute_name) : value&.public_send(attribute_name)
         end
       end
     end
+    def respond_to_missing?(...) = record.respond_to?(...) || super
   end
 
   attr_reader :record

--- a/test/active_record/associated_object_test.rb
+++ b/test/active_record/associated_object_test.rb
@@ -43,22 +43,13 @@ class ActiveRecord::AssociatedObjectTest < ActiveSupport::TestCase
   end
 
   test "introspection" do
-    assert_equal Post, @publisher.record_klass
-    assert_equal Post, Post::Publisher.record_klass
-
-    assert_equal :publisher, @publisher.attribute_name
+    assert_equal Post, Post::Publisher.record
     assert_equal :publisher, Post::Publisher.attribute_name
 
-    assert_equal Author, @archiver.record_klass
-    assert_equal Author, Author::Archiver.record_klass
-
-    assert_equal :archiver, @archiver.attribute_name
+    assert_equal Author, Author::Archiver.record
     assert_equal :archiver, Author::Archiver.attribute_name
 
-    assert_equal Post::Comment, @rating.record_klass
-    assert_equal Post::Comment, Post::Comment::Rating.record_klass
-
-    assert_equal :rating, @rating.attribute_name
+    assert_equal Post::Comment, Post::Comment::Rating.record
     assert_equal :rating, Post::Comment::Rating.attribute_name
   end
 


### PR DESCRIPTION
…`/`attribute_name` instance methods.

We're removing `record_klass` at both the instance and class level. We're also removing `attribute_name` at the instance level.

In hindsight I don't think either of the instance level methods are that helpful. Add this for full backwards compatibility though:

```ruby
ActiveRecord::AssociatedObject.alias_method :record_klass, :record
ActiveRecord::AssociatedObject.delegate :record_klass, :attribute_name, to: :class
```

Feel free to open an issue and explain how you're using these too!

----

We're also refactoring the internals here:

- We're extending ActiveModel::Naming to get `model_name` which is also useful for later features.
- We're eagerly defining the `record` and `attribute_name` methods, so people don't get `NoMethodError`'s.
- ^ but we'll still eagerly check the namespace is an `ActiveRecord::Base`` and verify it.
- We're using a double-dispatch refactoring in `associated_via` to slim `inherited` and make accessing the new object class's internals easier.

This is some of the oldest code in here, so I'm almost a little moody touching it. 😢