### PR TITLE
We can't extract Associated Objects from methods ending in `?` or `=`.

### DIFF
--- a/lib/active_record/associated_object.rb
+++ b/lib/active_record/associated_object.rb
@@ -25,16 +25,16 @@ class ActiveRecord::AssociatedObject
       record.class_eval(&block)
     end
 
-    def method_missing(method, ...)
-      if !record.respond_to?(method) then super else
-        record.public_send(method, ...).then do |value|
+    def method_missing(meth, ...)
+      if !record.respond_to?(meth) || meth.end_with?("?", "=") then super else
+        record.public_send(meth, ...).then do |value|
           value.respond_to?(:each) ? value.map(&attribute_name) : value&.public_send(attribute_name)
         end
       end
     end
 
-    def respond_to_missing?(name, ...)
-      (name != :abstract_class? && record.respond_to?(name, ...)) || super
+    def respond_to_missing?(meth, ...)
+      (record.respond_to?(meth, ...) && !meth.end_with?("?", "=")) || super
     end
   end
 

--- a/test/active_record/associated_object_test.rb
+++ b/test/active_record/associated_object_test.rb
@@ -31,6 +31,9 @@ class ActiveRecord::AssociatedObjectTest < ActiveSupport::TestCase
     assert_equal @publisher,     Post::Publisher.find_by(id: 1)
     assert_equal @publisher,     Post::Publisher.find_by(title: Post.first.title)
     assert_equal @publisher,     Post::Publisher.find_by(author: Author.first)
+    assert_equal @publisher,     Post::Publisher.find_by!(id: 1)
+    assert_equal @publisher,     Post::Publisher.find_by!(title: Post.first.title)
+    assert_equal @publisher,     Post::Publisher.find_by!(author: Author.first)
     assert_equal [ @publisher ], Post::Publisher.where(id: 1)
 
     assert_equal @rating,     Post::Comment::Rating.first
@@ -39,11 +42,24 @@ class ActiveRecord::AssociatedObjectTest < ActiveSupport::TestCase
     assert_equal @rating,     Post::Comment::Rating.find_by(Post::Comment::Rating.primary_key => [[@post.id, @author.id]])
     assert_equal @rating,     Post::Comment::Rating.find_by(body: "First!!!!")
     assert_equal @rating,     Post::Comment::Rating.find_by(author: Author.first)
+    assert_equal @rating,     Post::Comment::Rating.find_by!(Post::Comment::Rating.primary_key => [[@post.id, @author.id]])
+    assert_equal @rating,     Post::Comment::Rating.find_by!(body: "First!!!!")
+    assert_equal @rating,     Post::Comment::Rating.find_by!(author: Author.first)
     assert_equal [ @rating ], Post::Comment::Rating.where(Post::Comment::Rating.primary_key => [[@post.id, @author.id]])
   end
 
   test "associated object method missing extraction omittances" do
     refute_respond_to Post::Publisher, :abstract_class?
+    refute_respond_to Post::Publisher, :descends_from_active_record?
+
+    refute_respond_to Post::Publisher, :abstract_class=
+    refute_respond_to Post::Publisher, :primary_abstract_class=
+
+    assert_raise(NoMethodError) { Post::Publisher.abstract_class? }
+    assert_raise(NoMethodError) { Post::Publisher.descends_from_active_record? }
+
+    assert_raise(NoMethodError) { Post::Publisher.abstract_class = true }
+    assert_raise(NoMethodError) { Post::Publisher.primary_abstract_class = true }
   end
 
   test "introspection" do


### PR DESCRIPTION
Our `method_missing` based proxying is technically eager to hopefully allow us to support more of Active Record's surface area cheaply. It's been working well for over 3 years, but there's some issues.

Notably, a `record.respond_to?` check is not enough and there's certain methods we don't want to proxy.

Stuff like Active Record's class-level configuration API via `abtract_class?`, `descends_from_active_record?`, `abstract_class=` and `primary_abstract_class=` to name a few.

So ideally opting out of proxying methods that end in `?` and `=` should be safe.

I'm not including `!` to allow `find_by!` to work.

Ref: https://github.com/rubyevents/rubyevents/pull/873
Ref: #40